### PR TITLE
Changed yield attribute name due to clash

### DIFF
--- a/DatamodelB07/core/analysis.py
+++ b/DatamodelB07/core/analysis.py
@@ -46,5 +46,5 @@ class Analysis(sdRDM.DataModel):
         default="git://github.com/FAIRChemistry/datamodel_b07.git"
     )
     __commit__: Optional[str] = PrivateAttr(
-        default="b7f50d16a78a14617f5b1cda63573feae5c120fd"
+        default="5d48c0ab8715b2bafdb4436122baebae81b78633"
     )

--- a/DatamodelB07/core/apparatus.py
+++ b/DatamodelB07/core/apparatus.py
@@ -21,5 +21,5 @@ class Apparatus(sdRDM.DataModel):
         default="git://github.com/FAIRChemistry/datamodel_b07.git"
     )
     __commit__: Optional[str] = PrivateAttr(
-        default="b7f50d16a78a14617f5b1cda63573feae5c120fd"
+        default="5d48c0ab8715b2bafdb4436122baebae81b78633"
     )

--- a/DatamodelB07/core/author.py
+++ b/DatamodelB07/core/author.py
@@ -43,7 +43,7 @@ class Author(sdRDM.DataModel):
         default="git://github.com/FAIRChemistry/datamodel_b07.git"
     )
     __commit__: Optional[str] = PrivateAttr(
-        default="b7f50d16a78a14617f5b1cda63573feae5c120fd"
+        default="5d48c0ab8715b2bafdb4436122baebae81b78633"
     )
 
     def add_to_pid(

--- a/DatamodelB07/core/carbonization.py
+++ b/DatamodelB07/core/carbonization.py
@@ -36,5 +36,5 @@ class Carbonization(sdRDM.DataModel):
         default="git://github.com/FAIRChemistry/datamodel_b07.git"
     )
     __commit__: Optional[str] = PrivateAttr(
-        default="b7f50d16a78a14617f5b1cda63573feae5c120fd"
+        default="5d48c0ab8715b2bafdb4436122baebae81b78633"
     )

--- a/DatamodelB07/core/chemicalcompound.py
+++ b/DatamodelB07/core/chemicalcompound.py
@@ -48,5 +48,5 @@ class ChemicalCompound(sdRDM.DataModel):
         default="git://github.com/FAIRChemistry/datamodel_b07.git"
     )
     __commit__: Optional[str] = PrivateAttr(
-        default="b7f50d16a78a14617f5b1cda63573feae5c120fd"
+        default="5d48c0ab8715b2bafdb4436122baebae81b78633"
     )

--- a/DatamodelB07/core/dataset.py
+++ b/DatamodelB07/core/dataset.py
@@ -67,7 +67,7 @@ class Dataset(sdRDM.DataModel):
         default="git://github.com/FAIRChemistry/datamodel_b07.git"
     )
     __commit__: Optional[str] = PrivateAttr(
-        default="b7f50d16a78a14617f5b1cda63573feae5c120fd"
+        default="5d48c0ab8715b2bafdb4436122baebae81b78633"
     )
 
     def add_to_authors(

--- a/DatamodelB07/core/filmpreparation.py
+++ b/DatamodelB07/core/filmpreparation.py
@@ -31,5 +31,5 @@ class FilmPreparation(sdRDM.DataModel):
         default="git://github.com/FAIRChemistry/datamodel_b07.git"
     )
     __commit__: Optional[str] = PrivateAttr(
-        default="b7f50d16a78a14617f5b1cda63573feae5c120fd"
+        default="5d48c0ab8715b2bafdb4436122baebae81b78633"
     )

--- a/DatamodelB07/core/gpc.py
+++ b/DatamodelB07/core/gpc.py
@@ -36,5 +36,5 @@ class GPC(sdRDM.DataModel):
         default="git://github.com/FAIRChemistry/datamodel_b07.git"
     )
     __commit__: Optional[str] = PrivateAttr(
-        default="b7f50d16a78a14617f5b1cda63573feae5c120fd"
+        default="5d48c0ab8715b2bafdb4436122baebae81b78633"
     )

--- a/DatamodelB07/core/nmr.py
+++ b/DatamodelB07/core/nmr.py
@@ -41,5 +41,5 @@ class NMR(sdRDM.DataModel):
         default="git://github.com/FAIRChemistry/datamodel_b07.git"
     )
     __commit__: Optional[str] = PrivateAttr(
-        default="b7f50d16a78a14617f5b1cda63573feae5c120fd"
+        default="5d48c0ab8715b2bafdb4436122baebae81b78633"
     )

--- a/DatamodelB07/core/personalid.py
+++ b/DatamodelB07/core/personalid.py
@@ -25,5 +25,5 @@ class PersonalID(sdRDM.DataModel):
         default="git://github.com/FAIRChemistry/datamodel_b07.git"
     )
     __commit__: Optional[str] = PrivateAttr(
-        default="b7f50d16a78a14617f5b1cda63573feae5c120fd"
+        default="5d48c0ab8715b2bafdb4436122baebae81b78633"
     )

--- a/DatamodelB07/core/physicalparameter.py
+++ b/DatamodelB07/core/physicalparameter.py
@@ -31,5 +31,5 @@ class PhysicalParameter(sdRDM.DataModel):
         default="git://github.com/FAIRChemistry/datamodel_b07.git"
     )
     __commit__: Optional[str] = PrivateAttr(
-        default="b7f50d16a78a14617f5b1cda63573feae5c120fd"
+        default="5d48c0ab8715b2bafdb4436122baebae81b78633"
     )

--- a/DatamodelB07/core/physisorption.py
+++ b/DatamodelB07/core/physisorption.py
@@ -51,5 +51,5 @@ class Physisorption(sdRDM.DataModel):
         default="git://github.com/FAIRChemistry/datamodel_b07.git"
     )
     __commit__: Optional[str] = PrivateAttr(
-        default="b7f50d16a78a14617f5b1cda63573feae5c120fd"
+        default="5d48c0ab8715b2bafdb4436122baebae81b78633"
     )

--- a/DatamodelB07/core/processing.py
+++ b/DatamodelB07/core/processing.py
@@ -27,5 +27,5 @@ class Processing(sdRDM.DataModel):
         default="git://github.com/FAIRChemistry/datamodel_b07.git"
     )
     __commit__: Optional[str] = PrivateAttr(
-        default="b7f50d16a78a14617f5b1cda63573feae5c120fd"
+        default="5d48c0ab8715b2bafdb4436122baebae81b78633"
     )

--- a/DatamodelB07/core/reactant.py
+++ b/DatamodelB07/core/reactant.py
@@ -37,5 +37,5 @@ class Reactant(sdRDM.DataModel):
         default="git://github.com/FAIRChemistry/datamodel_b07.git"
     )
     __commit__: Optional[str] = PrivateAttr(
-        default="b7f50d16a78a14617f5b1cda63573feae5c120fd"
+        default="5d48c0ab8715b2bafdb4436122baebae81b78633"
     )

--- a/DatamodelB07/core/saxs.py
+++ b/DatamodelB07/core/saxs.py
@@ -61,5 +61,5 @@ class SAXS(sdRDM.DataModel):
         default="git://github.com/FAIRChemistry/datamodel_b07.git"
     )
     __commit__: Optional[str] = PrivateAttr(
-        default="b7f50d16a78a14617f5b1cda63573feae5c120fd"
+        default="5d48c0ab8715b2bafdb4436122baebae81b78633"
     )

--- a/DatamodelB07/core/stoichiometry.py
+++ b/DatamodelB07/core/stoichiometry.py
@@ -41,5 +41,5 @@ class Stoichiometry(sdRDM.DataModel):
         default="git://github.com/FAIRChemistry/datamodel_b07.git"
     )
     __commit__: Optional[str] = PrivateAttr(
-        default="b7f50d16a78a14617f5b1cda63573feae5c120fd"
+        default="5d48c0ab8715b2bafdb4436122baebae81b78633"
     )

--- a/DatamodelB07/core/synthesis.py
+++ b/DatamodelB07/core/synthesis.py
@@ -1,6 +1,6 @@
 import sdRDM
 
- 
+
 from typing import Optional
 from pydantic import PrivateAttr
 from sdRDM.base.listplus import ListPlus
@@ -13,48 +13,70 @@ from .filmpreparation import FilmPreparation
 from .physicalparameter import PhysicalParameter
 from .processing import Processing
 from .reactant import Reactant
+
+
 class Synthesis(sdRDM.DataModel):
 
-                
-    """...description...
-"""
+    """...description..."""
 
-    physical_parameters: List[PhysicalParameter] = Field(    
-    description="...",    default_factory=ListPlus,    )
+    physical_parameters: List[PhysicalParameter] = Field(
+        description="...",
+        default_factory=ListPlus,
+    )
 
-    apparatus: List[Apparatus] = Field(    
-    description="...",    default_factory=ListPlus,    )
+    apparatus: List[Apparatus] = Field(
+        description="...",
+        default_factory=ListPlus,
+    )
 
-    yield: float = Field(
-    ...,    description="Yield in percent",    )
+    yield_: float = Field(
+        ...,
+        description="Yield in percent",
+    )
 
-    notice: Optional[str] = Field(    
-    description="...",    default=None,    )
+    notice: Optional[str] = Field(
+        description="...",
+        default=None,
+    )
 
-    reactant: Optional[Reactant] = Field(    
-    description="...",    default=None,    )
+    reactant: Optional[Reactant] = Field(
+        description="...",
+        default=None,
+    )
 
-    reaction_type: List[str] = Field(    
-    description="Name of the reaction type",    default_factory=ListPlus,    )
+    reaction_type: List[str] = Field(
+        description="Name of the reaction type",
+        default_factory=ListPlus,
+    )
 
-    reactants: List[Reactant] = Field(    
-    description="All reactants that are involved in the reaction",    default_factory=ListPlus,    )
+    reactants: List[Reactant] = Field(
+        description="All reactants that are involved in the reaction",
+        default_factory=ListPlus,
+    )
 
-    solvent: Optional[str] = Field(    
-    description="Solvent used for the reaction",    default=None,    )
+    solvent: Optional[str] = Field(
+        description="Solvent used for the reaction",
+        default=None,
+    )
 
-    processing: List[Processing] = Field(    
-    description="All subsequent processing steps",    default_factory=ListPlus,    )
+    processing: List[Processing] = Field(
+        description="All subsequent processing steps",
+        default_factory=ListPlus,
+    )
 
-    __repo__: Optional[str] = PrivateAttr(default="git://github.com/FAIRChemistry/datamodel_b07.git")
-    __commit__: Optional[str] = PrivateAttr(default="b7f50d16a78a14617f5b1cda63573feae5c120fd")
-    
+    __repo__: Optional[str] = PrivateAttr(
+        default="git://github.com/FAIRChemistry/datamodel_b07.git"
+    )
+    __commit__: Optional[str] = PrivateAttr(
+        default="5d48c0ab8715b2bafdb4436122baebae81b78633"
+    )
+
     def add_to_reactants(
         self,
-        product: Optional[str] = None ,
-        educt: Optional[str] = None ,
-        catalyst: Optional[str] = None ,
-        cocatalyst: Optional[str] = None ,
+        product: Optional[str] = None,
+        educt: Optional[str] = None,
+        catalyst: Optional[str] = None,
+        cocatalyst: Optional[str] = None,
     ) -> None:
         """
         Adds an instance of 'Reactant' to the attribute 'reactants'.
@@ -74,11 +96,12 @@ class Synthesis(sdRDM.DataModel):
                 cocatalyst=cocatalyst,
             )
         )
+
     def add_to_physical_parameters(
         self,
-        temperature: Optional[float] = None ,
-        time: Optional[float] = None ,
-        pressure: Optional[float] = None ,
+        temperature: Optional[float] = None,
+        time: Optional[float] = None,
+        pressure: Optional[float] = None,
     ) -> None:
         """
         Adds an instance of 'PhysicalParameter' to the attribute 'physical_parameters'.
@@ -96,9 +119,10 @@ class Synthesis(sdRDM.DataModel):
                 pressure=pressure,
             )
         )
+
     def add_to_apparatus(
         self,
-        field: Optional[str] = None ,
+        field: Optional[str] = None,
     ) -> None:
         """
         Adds an instance of 'Apparatus' to the attribute 'apparatus'.
@@ -112,10 +136,11 @@ class Synthesis(sdRDM.DataModel):
                 field=field,
             )
         )
+
     def add_to_processing(
         self,
-        field: Optional[str] = None ,
-        film_preparation: Optional[FilmPreparation] = None ,
+        field: Optional[str] = None,
+        film_preparation: Optional[FilmPreparation] = None,
     ) -> None:
         """
         Adds an instance of 'Processing' to the attribute 'processing'.

--- a/DatamodelB07/schemes/Data model for CRC 1333 project B07.md
+++ b/DatamodelB07/schemes/Data model for CRC 1333 project B07.md
@@ -50,7 +50,7 @@ classDiagram
         +PhysicalParameter[0..*] physical_parameters*
         +Apparatus[0..*] apparatus
         +Processing[0..*] processing
-        +float yield*
+        +float yield_*
         +string notice
         +Reactant reactant
     }

--- a/DatamodelB07/schemes/Data model for CRC 1333 project B07_metadata.json
+++ b/DatamodelB07/schemes/Data model for CRC 1333 project B07_metadata.json
@@ -92,7 +92,7 @@
         "description": "All subsequent processing steps",
         "multiple": "True"
       },
-      "yield": {
+      "yield_": {
         "description": "Yield in percent"
       },
       "notice": {

--- a/specifications/datamodel_b07.md
+++ b/specifications/datamodel_b07.md
@@ -100,7 +100,7 @@ Container for personal identifiers related to an author
   - Type: Processing
   - Description: All subsequent processing steps
   - Multiple: True
-- __yield*__
+- __yield_*__
   - Type: float
   - Description: Yield in percent
 - __notice__


### PR DESCRIPTION
Due to Python internals, the name ```yield``` is forbidden. I changed it to ```yield_``` so it doesn't throw an error.